### PR TITLE
Auto get local ip for TseerServer & TseerAgent and some other enhancement

### DIFF
--- a/TseerAgent/TseerAgent.conf
+++ b/TseerAgent/TseerAgent.conf
@@ -3,8 +3,8 @@
     installpath=/usr/local
     #路由服务中心地址，必填
 	locator=Tseer.TseerServer.QueryObj@tcp -h 127.0.0.1 -p 9903
-	#方便云端路由中心管理的地址，必须是非127.0.0.1
-	localip=127.0.0.1
+	#方便云端路由中心管理的地址，必须是非127.0.0.1，自动获取，如自动获取失败，手动填写可生效
+	#localip=127.0.0.1
 	#提供给api查询的地址，默认是127.0.0.1
 	#routerip=127.0.0.1
 </server>

--- a/TseerAgent/src/TseerAgentServer.cpp
+++ b/TseerAgent/src/TseerAgentServer.cpp
@@ -349,6 +349,14 @@ int parseConfig(int argc, char *argv[])
         usage();
     }
 
+    //获取本机配置的 ip (IPV4)
+    char iface[8];
+    char ip[INET_ADDRSTRLEN];
+    if (!get_default_if(iface, 8) || !get_ip(iface, ip, INET_ADDRSTRLEN)) {
+        cerr << FILE_FUN << " get default ip via /proc/net/route failed, using default value instead" << endl;
+        memset(ip, 0, INET_ADDRSTRLEN);
+    }
+
     //读取配置文件
     if(!TC_File::isFileExistEx(configFile)) {
         cerr <<configFile << " file don't exist!" << endl;
@@ -395,7 +403,7 @@ int parseConfig(int argc, char *argv[])
     }
 
     //主要是要注册到路由中心方便云端管理，所以这里必须是内网ip
-    std::string innerIp = paramConf.get("/server<localip>", "");
+    std::string innerIp = paramConf.get("/server<localip>", ip);
     
     //默认是绑定本地127.0.0.1,提供给api访问
     std::string routerIp = paramConf.get("/server<routerip>", "127.0.0.1");

--- a/TseerAgent/src/TseerAgentServer.cpp
+++ b/TseerAgent/src/TseerAgentServer.cpp
@@ -343,18 +343,14 @@ int parseConfig(int argc, char *argv[])
     }
     
     string configFile = "";
-    if (Op.hasParam("config"))
-    {
+    if (Op.hasParam("config")) {
         configFile = Op.getValue("config");
-    }
-    else
-    {
+    } else {
         usage();
     }
 
     //读取配置文件
-    if(!TC_File::isFileExistEx(configFile))
-    {
+    if(!TC_File::isFileExistEx(configFile)) {
         cerr <<configFile << " file don't exist!" << endl;
         exit(-1);
     }
@@ -363,64 +359,47 @@ int parseConfig(int argc, char *argv[])
     paramConf.parseFile(configFile);
 
     string sInstallpatch = paramConf.get("/server<installpath>", "");
-    if(sInstallpatch.empty())
-    {
+    if(sInstallpatch.empty()) {
         sInstallpatch = g_app.g_installPath;
     }
-    else
-    {
-        //记录安装路径
-        g_app.g_installPath = sInstallpatch;
-    }
     
+    //解析主控地址列表
     std::string locator = paramConf.get("/server<locator>", "");
-
-    //主要是要注册到路由中心方便云端管理，所以这里必须是内网ip
-    std::string innerIp = paramConf.get("/server<localip>", "");
-    
-    //默认是绑定本地127.0.0.1,提供给api访问
-    std::string routerIp = paramConf.get("/server<routerip>", "127.0.0.1");
-    if (locator.empty())
-    {
+    if (locator.empty()) {
         cerr<<"you should provide locator"<<endl;
         exit(-1);
     }
-
-    //解析主控地址列表
-    if(locator.find("@") == string::npos)
-    {
+    if(locator.find("@") == string::npos) {
         string tmpList;
         vector<string> ipPortlist = TC_Common::sepstr<string>(locator,"|;");
-        for (size_t i = 0; i < ipPortlist.size(); i++)
-        {
+        for (size_t i = 0; i < ipPortlist.size(); i++) {
             vector<string> ipPort = TC_Common::sepstr<string>(ipPortlist[i],":");
-            if(ipPort.size() < 2)
-            {
+            if(ipPort.size() < 2) {
                 cerr<<FILE_FUN<< ipPortlist[i]<<" is invalid"<<endl;
                 continue;
             }
             
             string endPoint= "tcp -h " + ipPort[0] + " -p " + ipPort[1];
-            if (tmpList != "")
-            {
+            if (tmpList != "") {
                 tmpList += ":" + endPoint;
-            }
-            else
-            {
+            } else {
                 tmpList = endPoint;
             }
         }
 
-        if(tmpList.empty())
-        {
+        if(tmpList.empty()) {
             cerr<<"invalid locator param:"<<locator<<endl;
             exit(-1);
         }
         locator = TSEERSERVER_MODULE + ".QueryObj@"+tmpList;
     }
 
-    if(routerIp.empty())
-    {
+    //主要是要注册到路由中心方便云端管理，所以这里必须是内网ip
+    std::string innerIp = paramConf.get("/server<localip>", "");
+    
+    //默认是绑定本地127.0.0.1,提供给api访问
+    std::string routerIp = paramConf.get("/server<routerip>", "127.0.0.1");
+    if(routerIp.empty()) {
         //监听127.0.0.1
         routerIp = "127.0.0.1";
     }
@@ -436,53 +415,54 @@ int parseConfig(int argc, char *argv[])
         }
     }
     
-    g_app.g_configFile = confPath + "/."+TSEERAGENT_SERVERNAME + ".conf";
-    g_app.g_innerIp = innerIp;
-
+    g_app.g_installPath = sInstallpatch;
+    g_app.g_configFile  = confPath + "/."+TSEERAGENT_SERVERNAME + ".conf";
+    g_app.g_innerIp     = innerIp;
     
     TC_Config           newConf;
     map<string, string> m;
     
-    //server config
-    m["app"]= TSEERAGENT_APPNAME;
-    m["server"]= TSEERAGENT_SERVERNAME;
     string sModuleName = TSEERAGENT_APPNAME + "." + TSEERAGENT_SERVERNAME;
-    m["localip"]= innerIp;
+
+    //server config
+    m["app"]      = TSEERAGENT_APPNAME;
+    m["server"]   = TSEERAGENT_SERVERNAME;
+    m["localip"]  = innerIp;
     // #服务的可执行文件
-    m["basepath"]= TC_File::simplifyDirectory(sInstallpatch + "/"+TSEERAGENT_APPNAME+ "/" + TSEERAGENT_SERVERNAME+"/bin/");
+    m["basepath"] = TC_File::simplifyDirectory(sInstallpatch + "/"+TSEERAGENT_APPNAME+ "/" + TSEERAGENT_SERVERNAME+"/bin/");
     //服务的数据目录
-    m["datapath"]= TC_File::simplifyDirectory(sInstallpatch + "/" + TSEERAGENT_APPNAME + "/" + TSEERAGENT_SERVERNAME+"/data");
-    m["logpath"]= TC_File::simplifyDirectory(sInstallpatch + "/" + TSEERAGENT_APPNAME + "/" + TSEERAGENT_SERVERNAME +"/app_log");
-    m["logLevel"]= "DEBUG";
+    m["datapath"] = TC_File::simplifyDirectory(sInstallpatch + "/" + TSEERAGENT_APPNAME + "/" + TSEERAGENT_SERVERNAME+"/data");
+    m["logpath"]  = TC_File::simplifyDirectory(sInstallpatch + "/" + TSEERAGENT_APPNAME + "/" + TSEERAGENT_SERVERNAME +"/app_log");
+    m["logLevel"] = paramConf.get("/server<logLevel>", "DEBUG");
     //滚动日志大小和个数
-    m["logsize"]= TC_Common::tostr(1024*1024*15);
+    m["logsize"]  = TC_Common::tostr(1024*1024*15);
     m["closecout"] = "1";
     newConf.insertDomainParam( "/tars/application/server", m, true);
 
     //servant config
     m.clear();
-    m["endpoint"]= "udp -h " + routerIp +" -p 8865 -t 60000";
-    m["maxconns"]= "10000";
-    m["threads"]= "8";
-    m["queuecap"]= "10000";
+    m["endpoint"] = "udp -h " + routerIp +" -p 8865 -t 60000";
+    m["maxconns"] = "10000";
+    m["threads"]  = "8";
+    m["queuecap"] = "10000";
     m["protocol"] = "tars";
     m["queuetimeout"] = "60000";
-    m["servant"] = sModuleName + ".RouterObj";
-    m["allow"] = "";
+    m["servant"]  = sModuleName + ".RouterObj";
+    m["allow"]    = "";
     m["handlegroup"] = "RouterObjAdapter";
     newConf.insertDomainParam( "/tars/application/server/RouterObjAdapter", m, true);
 
     if(!g_app.g_innerIp.empty())
     {
         m.clear();
-        m["endpoint"]= "tcp -h " + g_app.g_innerIp +" -p 9765 -t 60000";
-        m["maxconns"]= "10000";
-        m["threads"]= "5";
-        m["queuecap"]= "10000";
+        m["endpoint"] = "tcp -h " + g_app.g_innerIp +" -p 9765 -t 60000";
+        m["maxconns"] = "10000";
+        m["threads"]  = "5";
+        m["queuecap"] = "10000";
         m["protocol"] = "tars";
         m["queuetimeout"] = "60000";
-        m["servant"] = sModuleName + ".UpdateObj";
-        m["allow"] = "";
+        m["servant"]  = sModuleName + ".UpdateObj";
+        m["allow"]    = "";
         m["handlegroup"] = "UpdateObjAdapter";
         newConf.insertDomainParam( "/tars/application/server/UpdateObjAdapter", m, true);
     }

--- a/TseerAgent/src/util.h
+++ b/TseerAgent/src/util.h
@@ -2,13 +2,13 @@
  * Tencent is pleased to support the open source community by making Tseer available.
  *
  * Copyright (C) 2018 THL A29 Limited, a Tencent company. All rights reserved.
- * 
+ *
  * Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * https://opensource.org/licenses/BSD-3-Clause
  *
- * Unless required by applicable law or agreed to in writing, software distributed 
+ * Unless required by applicable law or agreed to in writing, software distributed
  * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
@@ -17,8 +17,12 @@
 #ifndef _UTIL_H
 #define _UTIL_H
 
+#include <netinet/in.h>
+#include <sys/types.h>
+#include <ifaddrs.h>
 #include "util/tc_common.h"
 #include "RollLogger.h"
+
 
 inline bool popen_sendMsg(const string& sCommand)
 {
@@ -47,5 +51,46 @@ inline string display(const T& t)
     t.displaySimple(stream);
     return(stream.str());
 }
-#endif
 
+// get default network interface
+inline bool get_default_if(char *iface, int size) {
+    if (size < 8) return false;
+    memset(iface, 0, size);
+
+    FILE *f = fopen("/proc/net/route", "r");
+    if (!f) return false;
+
+    char dest[64]  = {0, };
+    while (!feof(f)) {
+        if (fscanf(f, "%s %s %*[^\r\n]%*c", iface, dest) != 2) continue;
+        if (strcmp(dest, "00000000") == 0) {
+            break;
+        }
+    }
+
+    return strlen(iface) ? true : false;
+}
+
+// get eth0's ipv4 address
+inline bool get_ip(const char *iface, char* ip, int size) {
+    if (size < INET_ADDRSTRLEN) return false;
+    memset(ip, 0, size);
+
+    struct ifaddrs * ifAddrStruct = NULL;
+    struct ifaddrs * ifa = NULL;
+    void * tmpAddrPtr = NULL;
+
+    getifaddrs(&ifAddrStruct);
+    for (ifa = ifAddrStruct; ifa != NULL; ifa = ifa->ifa_next) {
+        if ((ifa->ifa_addr->sa_family == AF_INET) && (strcmp(ifa->ifa_name,iface) == 0)) {
+            tmpAddrPtr = &((struct sockaddr_in *)ifa->ifa_addr)->sin_addr;
+            inet_ntop(AF_INET, tmpAddrPtr, ip, INET_ADDRSTRLEN);
+        }
+    }
+
+    if (ifAddrStruct != NULL) freeifaddrs(ifAddrStruct);
+
+    return strlen(ip) ? true : false;
+}
+
+#endif

--- a/TseerServer/TseerServer.conf
+++ b/TseerServer/TseerServer.conf
@@ -1,8 +1,8 @@
 <server>
     #服务安装路径，默认是/usr/local，必填
     installpath=/home/louishuang/onlineseer/seer/mytest
-    #服务绑定本机地址，必填
-    localip=127.0.0.1
+    #服务绑定本机地址，自动获取，如失败，手动填写可生效
+    #localip=127.0.0.1
     #服务日志等级，默认是DEBUG
     logLevel=DEBUG
     #服务默认的存储方式可选：etcd/mysql，默认是etcd

--- a/TseerServer/src/TSeerServer.cpp
+++ b/TseerServer/src/TSeerServer.cpp
@@ -264,6 +264,14 @@ int parseConfig(int argc, char *argv[])
         useAge();
     }
 
+    //获取本机配置的 ip (IPV4)
+    char iface[8];
+    char ip[INET_ADDRSTRLEN];
+    if (!get_default_if(iface, 8) || !get_ip(iface, ip, INET_ADDRSTRLEN)) {
+        cerr << FILE_FUN << " get default ip via /proc/net/route failed, using 127.0.0.1 instead" << endl;
+        strcpy(ip, "127.0.0.1");
+    }
+
     //读取配置文件
     if(!TC_File::isFileExistEx(configFile))
     {
@@ -297,7 +305,7 @@ int parseConfig(int argc, char *argv[])
         #endif
     }
 
-    string sInnerIp = conf.get("/server<localip>", "127.0.0.1");
+    string sInnerIp = conf.get("/server<localip>", ip);
     string regPort = conf.get("/server<regport>", "9902");
     string queryPort = conf.get("/server<queryport>", "9903");
     string apiPort = conf.get("/server<apiport>", "9904");

--- a/TseerServer/src/util.h
+++ b/TseerServer/src/util.h
@@ -2,13 +2,13 @@
  * Tencent is pleased to support the open source community by making Tseer available.
  *
  * Copyright (C) 2018 THL A29 Limited, a Tencent company. All rights reserved.
- * 
+ *
  * Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * https://opensource.org/licenses/BSD-3-Clause
  *
- * Unless required by applicable law or agreed to in writing, software distributed 
+ * Unless required by applicable law or agreed to in writing, software distributed
  * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
@@ -21,6 +21,9 @@
 #include <vector>
 #include <set>
 #include <math.h>
+#include <netinet/in.h>
+#include <sys/types.h>
+#include <ifaddrs.h>
 #include "util/tc_common.h"
 #include "servant/TarsLogger.h"
 #include "reg_roll_logger.h"
@@ -70,7 +73,7 @@ using namespace Tseer;
     url += key;\
     url += "=";\
     url += value;\
-}while(0) 
+}while(0)
 
 #define CHECK_SETVALUE(key) if (jData.HasMember(#key) && jData[#key].IsString())\
         {\
@@ -82,7 +85,7 @@ using namespace Tseer;
             ret = API_INVALID_PARAM;\
             break;\
         }
-        
+
 #define CHECK_SETKEYVALUE(key, value) if (jData.HasMember(key) && jData[key].IsString())\
         {\
             value = jData[key].GetString();\
@@ -93,7 +96,7 @@ using namespace Tseer;
             ret = API_INVALID_PARAM;\
             break;\
         }
-        
+
 
 //用于遍历数据Json
 #define EXIST_GETVALUE_A(rvalue,key) do{\
@@ -181,7 +184,7 @@ namespace tars
     {
         return(TC_Common::tostr(t.begin(), t.end(), ","));
     }
-    
+
     template <>
     inline string TC_Common::tostr(const set<double>&t)
     {
@@ -243,21 +246,21 @@ inline bool needUpdate(const string& oldVer, const string& newVer,Compare f)
       */
      vector<string> oldVerList = TC_Common::sepstr<string>(oldVer, ".");
      vector<string> newVerList = TC_Common::sepstr<string>(newVer, ".");
-    
+
      if(oldVerList.size() != 2 || newVerList.size() != 2)
      {
          return false;
      }
-    
+
      string masterOldVer = oldVerList[0].substr(1, oldVerList[0].length() - 1);
      string masterNewVer = newVerList[0].substr(1, newVerList[0].length() - 1);
-    
+
      if(!TC_Common::isdigit(masterOldVer) || !TC_Common::isdigit(oldVerList[1])
              || !TC_Common::isdigit(masterNewVer) || !TC_Common::isdigit(newVerList[1]))
      {
          return false;
      }
-    
+
      int masterOldV = TC_Common::strto<int>(masterOldVer);
      int masterNewV = TC_Common::strto<int>(masterNewVer);
      if(masterOldV == masterNewV)
@@ -282,5 +285,45 @@ inline bool needUpdate(const string& oldVer, const string& newVer,Compare f)
 
 }
 
-#endif
+// get default network interface
+inline bool get_default_if(char *iface, int size) {
+    if (size < 8) return false;
+    memset(iface, 0, size);
 
+    FILE *f = fopen("/proc/net/route", "r");
+    if (!f) return false;
+
+    char dest[64]  = {0, };
+    while (!feof(f)) {
+        if (fscanf(f, "%s %s %*[^\r\n]%*c", iface, dest) != 2) continue;
+        if (strcmp(dest, "00000000") == 0) {
+            break;
+        }
+    }
+
+    return strlen(iface) ? true : false;
+}
+
+// get eth0's ipv4 address
+inline bool get_ip(const char *iface, char* ip, int size) {
+    if (size < INET_ADDRSTRLEN) return false;
+    memset(ip, 0, size);
+
+    struct ifaddrs * ifAddrStruct = NULL;
+    struct ifaddrs * ifa = NULL;
+    void * tmpAddrPtr = NULL;
+
+    getifaddrs(&ifAddrStruct);
+    for (ifa = ifAddrStruct; ifa != NULL; ifa = ifa->ifa_next) {
+        if ((ifa->ifa_addr->sa_family == AF_INET) && (strcmp(ifa->ifa_name,iface) == 0)) {
+            tmpAddrPtr = &((struct sockaddr_in *)ifa->ifa_addr)->sin_addr;
+            inet_ntop(AF_INET, tmpAddrPtr, ip, INET_ADDRSTRLEN);
+        }
+    }
+
+    if (ifAddrStruct != NULL) freeifaddrs(ifAddrStruct);
+
+    return strlen(ip) ? true : false;
+}
+
+#endif

--- a/api/cplus/demo/main_get_instance.cpp
+++ b/api/cplus/demo/main_get_instance.cpp
@@ -1,0 +1,107 @@
+/**
+ * Tencent is pleased to support the open source community by making Tseer available.
+ *
+ * Copyright (C) 2018 THL A29 Limited, a Tencent company. All rights reserved.
+ *
+ * Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string>
+#include <unistd.h>
+#include "include/Tseer_api.h"
+#include "include/Tseer_comm.h"
+
+using namespace std;
+using namespace Tseerapi;
+
+int main(int argc, char *argv[]) {
+    const char* service_name = NULL;
+    int option = 0x001;
+
+    int opt;
+    opterr = 0;
+    while ((opt = getopt(argc, argv, "iptah")) != -1) {
+        switch(opt) {
+            case 'a':
+                option |= 0x111;
+                break;
+            case 'i':
+                option |= 0x001;
+                break;
+            case 'p':
+                option |= 0x010;
+                break;
+            case 't':
+                option |= 0x100;
+                break;
+            case 'h':
+                printf("Usage: %s [OPTION] service_name\n", argv[0]);
+                printf("  -a\tprint all fileds\n");
+                printf("  -i\tprint ip\n");
+                printf("  -p\tprint port\n");
+                printf("  -t\tprint tag\n");
+                printf("  -h\tprint help message\n");
+                exit(0);
+            default:
+                break;
+        }
+    }
+
+    if (optind >= argc) {
+        fprintf(stderr, "Error: no service name, use -h for help\n");
+        exit(1);
+    }
+
+    service_name = argv[optind];
+    string sErr;
+
+    InitAgentApiParams initParams;
+    if (ApiSetAgentIpInfo(initParams, sErr) != 0) {
+        fprintf(stderr, "Error: init agent error\n");
+        exit(2);
+    }
+
+    RoutersRequest reqs;
+    reqs.obj        = service_name;
+    reqs.lbGetType  = LB_GET_ALL;
+    if (ApiGetRoutes(reqs, sErr) == 0) {
+        vector<NodeInfo>::iterator vIter;
+        for (vIter = reqs.nodeInfoVec.begin(); vIter != reqs.nodeInfoVec.end(); ++vIter) {
+            bool need_tab = false;
+            if (option & 0x001) {
+                if (need_tab) printf("\t");
+                printf("%s", vIter->ip.c_str());
+                need_tab = true;
+            }
+
+            if (option & 0x010) {
+                if (need_tab) printf("\t");
+                printf("%d", vIter->port);
+                need_tab = true;
+            }
+
+            if (option & 0x100) {
+                if (need_tab) printf("\t");
+                printf("%s", vIter->slaveSet.empty() ? "-" : vIter->slaveSet.c_str());
+                need_tab = true;
+            }
+
+            if (need_tab) printf("\n");
+        }
+    } else {
+        fprintf(stderr, "Error: get service [%s] info failed\n", service_name);
+        exit(3);
+    }
+
+    return 0;
+}

--- a/api/cplus/src/global.h
+++ b/api/cplus/src/global.h
@@ -132,10 +132,14 @@ std::string getUnkeyFromReq(const InnerRouterRequest &req);
 //合并错误信息,currErr本层错误信息，subErr上层的错误信息
 std::string mergeErrMsg(const std::string &currErr, const std::string &subErr);
 
+//定义缓存文件的路径
+#ifndef ROUTERSCACHE_PATH
+#define ROUTERSCACHE_PATH "/tmp/.routersCache/"
+#endif
+
 #ifndef FILE_FUN
 #define FILE_FUN  __FILE__<<":"<<__FUNCTION__<<":"<<__LINE__<<"|"
 #endif
-
 }
 
 #endif

--- a/build/cmake/resolve_dependency.sh
+++ b/build/cmake/resolve_dependency.sh
@@ -2,12 +2,16 @@
 
 TIMESTAMP=`date "+%F %T"`
 
-echo "[INFO] $TIMESTAMP resolve depedency rapidjson..."
-git clone https://github.com/Tencent/rapidjson.git >/dev/null
+if [ -e "./rapidjson" ]; then
+    echo "[INFO] $TIMESTAMP rapidjson already downloaded."
+else
+    echo "[INFO] $TIMESTAMP resolve depedency rapidjson..."
+    git clone https://github.com/Tencent/rapidjson.git >/dev/null
 
-if [ "$?" -ne "0" ]; then
-    echo "[ERROR] $TIMESTAMP Download rapidjson failed."
-    exit 3
+    if [ "$?" -ne "0" ]; then
+        echo "[ERROR] $TIMESTAMP Download rapidjson failed."
+        exit 3
+    fi
 fi
 
 mkdir -p ../thirdparty/

--- a/docs/cplus-api-quickstart.md
+++ b/docs/cplus-api-quickstart.md
@@ -280,7 +280,6 @@ int main()
 	req.obj = "tencent.tencentServer.HelloService";
 	req.lbGetType = LB_GET_SET;
 	req.setInfo = "sz.a.b";
-	req.type = LB_TYPE_ALL;
 
 	iRet = ApiGetRoutes(req, errMsg);
 	if (iRet == 0) {


### PR DESCRIPTION
1. TseerAgent 多机批量部署时需要替换 conf 中的 localip，现改为，配置中不指定时自动获取，否则使用配置中指定的 ip，TseerServer 同
2. 将本地缓存的路径从./routersCache 移到 /tmp/.routersCache，避免执行命令时到处都有缓存目录
3. 增加命令get_instance 的实现，可用于命令行环境查询服务信息
4. 一些编译、监控脚本的改进和一些细节错误的修改

1. TseerAgent and TseerServer can get local IP automatically if no 'localip' option in config file, which is convenient for batch deployment on multiple machines
2. Change default cache directory from "./routersCache" to "/tmp/.routersCache", avoid leaving cache files everywhere after executing relevant commands
3. Add implementation of "get_instance" cmd for getting ip, port and set in terminal environment, see api/cplus/demo/main_get_instance.cpp.
4. some enhancement for compiling and monitoring scripts and fix some typo errors