### PR TITLE
fix(security): add authentication filter and remove hardcoded credent…

### DIFF
--- a/web/src/main/java/com/qq/seer/agent/SeerAgentModule.java
+++ b/web/src/main/java/com/qq/seer/agent/SeerAgentModule.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
+import com.qq.seer.common.filter.AuthContext;
 import com.qq.seer.http.SeerInterface;
 
 public class SeerAgentModule {
@@ -254,7 +255,11 @@ public class SeerAgentModule {
 	 public static JSONObject getServiceGroup(long logId) {
 		String interfaceName = "getservicegroup";
 		JSONObject paramsObj = new JSONObject();
-		paramsObj.put("rtx", "adminrtx");
+		// Fixed: operator identity from authenticated user context instead of hardcoded "adminrtx"
+		String currentUser = AuthContext.getCurrentUser();
+		if (currentUser != null && !currentUser.isEmpty()) {
+			paramsObj.put("rtx", currentUser);
+		}
 		JSONObject resultObj = SeerInterface.callSeerInterface(logId, paramsObj, interfaceName);
 		return resultObj;
 	 }
@@ -417,7 +422,11 @@ public class SeerAgentModule {
 		
 		JSONObject paramsObj = new JSONObject();
 		paramsObj.put("iplist", ipList);
-		paramsObj.put("key", "webadmin");
+		// Fixed: operator identity from authenticated user context instead of hardcoded "webadmin"
+		String operatorKey = AuthContext.getCurrentUserKey();
+		if (operatorKey != null && !operatorKey.isEmpty()) {
+			paramsObj.put("key", operatorKey);
+		}
 		
 		JSONObject resultObj = SeerInterface.callSeerInterface(logId, paramsObj, interfaceName);
 		return resultObj;

--- a/web/src/main/java/com/qq/seer/common/filter/AuthContext.java
+++ b/web/src/main/java/com/qq/seer/common/filter/AuthContext.java
@@ -1,0 +1,100 @@
+/**
+ * Tencent is pleased to support the open source community by making Tseer available.
+ *
+ * Copyright (C) 2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * 
+ * Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed 
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.qq.seer.common.filter;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * AuthContext provides thread-local access to the current authenticated user
+ * identity information. It is populated by AuthFilter and consumed by
+ * downstream modules (e.g., SeerAgentModule) to replace hardcoded admin
+ * credentials.
+ * 
+ * Usage flow:
+ * 1. AuthFilter resolves authenticated user from session/header
+ * 2. AuthFilter stores user info in both request attributes and AuthContext thread-local
+ * 3. Downstream code calls AuthContext.getCurrentUser() / getCurrentUserKey()
+ * 4. AuthFilter cleans up thread-local after request processing
+ */
+public class AuthContext {
+
+    /** Thread-local storage for current authenticated user. */
+    private static final ThreadLocal<String> currentUser = new ThreadLocal<>();
+
+    /** Thread-local storage for current authenticated user's operator key. */
+    private static final ThreadLocal<String> currentUserKey = new ThreadLocal<>();
+
+    /** Request attribute key for authenticated user (set by AuthFilter). */
+    public static final String AUTH_USER_ATTR = "SEER_AUTH_USER";
+
+    /** Request attribute key for admin role flag (set by AuthFilter). */
+    public static final String AUTH_IS_ADMIN_ATTR = "SEER_AUTH_IS_ADMIN";
+
+    /**
+     * Get the current authenticated user's username.
+     * @return username string, or null if not set
+     */
+    public static String getCurrentUser() {
+        return currentUser.get();
+    }
+
+    /**
+     * Get the current authenticated user's operator key.
+     * In production, this should map to a real permission token or key derived
+     * from the user's role and authorized scope.
+     * @return operator key string, or null if not set
+     */
+    public static String getCurrentUserKey() {
+        return currentUserKey.get();
+    }
+
+    /**
+     * Set the current authenticated user info into thread-local context.
+     * Called by AuthFilter after successful authentication.
+     * @param user the authenticated username
+     * @param userKey the authenticated user's operator key
+     */
+    public static void setCurrentUser(String user, String userKey) {
+        currentUser.set(user);
+        currentUserKey.set(userKey);
+    }
+
+    /**
+     * Initialize AuthContext from request attributes (set by AuthFilter).
+     * This provides a bridge between the servlet request and thread-local context
+     * for code that does not have direct access to the HttpServletRequest.
+     * @param request the HTTP request containing auth attributes
+     */
+    public static void initFromRequest(HttpServletRequest request) {
+        Object user = request.getAttribute(AUTH_USER_ATTR);
+        if (user != null) {
+            currentUser.set(user.toString());
+            // Derive userKey from the authenticated user identity
+            // In production, this should be a proper key derived from role/permission system
+            currentUserKey.set(user.toString());
+        }
+    }
+
+    /**
+     * Clear the current thread-local context.
+     * Must be called after request processing to prevent memory leaks.
+     */
+    public static void clear() {
+        currentUser.remove();
+        currentUserKey.remove();
+    }
+}

--- a/web/src/main/java/com/qq/seer/common/filter/AuthFilter.java
+++ b/web/src/main/java/com/qq/seer/common/filter/AuthFilter.java
@@ -1,0 +1,244 @@
+/**
+ * Tencent is pleased to support the open source community by making Tseer available.
+ *
+ * Copyright (C) 2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * 
+ * Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed 
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.qq.seer.common.filter;
+
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * AuthFilter provides unified authentication and authorization for management
+ * routes (/interface and *.action). Anonymous requests are rejected by default.
+ * 
+ * Management actions (Agent management, package management, installation tools,
+ * service group management) require authenticated admin role.
+ */
+public class AuthFilter implements Filter {
+
+    private static final Logger log = LoggerFactory.getLogger(AuthFilter.class);
+
+    /** HTTP header name for authenticated user identity. */
+    private static final String AUTH_USER_HEADER = "X-Auth-User";
+
+    /** Session attribute key for storing authenticated user. */
+    private static final String AUTH_USER_SESSION_ATTR = "SEER_AUTH_USER";
+
+    /** Session attribute key for storing user admin role flag. */
+    private static final String AUTH_IS_ADMIN_SESSION_ATTR = "SEER_AUTH_IS_ADMIN";
+
+    /** Admin role identifier. */
+    private static final String ADMIN_ROLE = "admin";
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        log.info("AuthFilter initialized");
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+        HttpServletResponse httpResponse = (HttpServletResponse) response;
+
+        String requestURI = httpRequest.getRequestURI();
+        String contextPath = httpRequest.getContextPath();
+        if (contextPath != null && requestURI.startsWith(contextPath)) {
+            requestURI = requestURI.substring(contextPath.length());
+        }
+
+        // Resolve authenticated user from session or auth header
+        String authUser = resolveAuthenticatedUser(httpRequest);
+        boolean isAdmin = checkAdminRole(httpRequest, authUser);
+
+        // Reject unauthenticated requests
+        if (authUser == null || authUser.isEmpty()) {
+            log.warn("Anonymous access rejected for URI: {}", requestURI);
+            sendAuthError(httpResponse, "Authentication required. Please login first.");
+            return;
+        }
+
+        // For management actions requiring admin privilege, check role
+        if (isAdminAction(requestURI, httpRequest) && !isAdmin) {
+            log.warn("Non-admin user [{}] access denied for admin URI: {}", authUser, requestURI);
+            sendForbiddenError(httpResponse, "Admin privilege required for this operation.");
+            return;
+        }
+
+        // Store authenticated user info in request attributes for downstream use
+        httpRequest.setAttribute(AUTH_USER_ATTR, authUser);
+        httpRequest.setAttribute(AUTH_IS_ADMIN_ATTR, isAdmin);
+
+        // Initialize AuthContext thread-local for downstream modules
+        // (e.g., SeerAgentModule) to access current user identity
+        AuthContext.setCurrentUser(authUser, authUser);
+
+        try {
+            chain.doFilter(request, response);
+        } finally {
+            // Clean up thread-local to prevent memory leaks
+            AuthContext.clear();
+        }
+    }
+
+    @Override
+    public void destroy() {
+        log.info("AuthFilter destroyed");
+    }
+
+    /**
+     * Resolve the authenticated user identity from session or auth header.
+     * In production, this should be replaced with a real authentication mechanism
+     * (e.g., OAuth2, SSO, Kerberos, etc.).
+     */
+    private String resolveAuthenticatedUser(HttpServletRequest request) {
+        // First check session for authenticated user
+        Object sessionUser = request.getSession(false) != null
+                ? request.getSession(false).getAttribute(AUTH_USER_SESSION_ATTR)
+                : null;
+        if (sessionUser != null && !sessionUser.toString().isEmpty()) {
+            return sessionUser.toString();
+        }
+
+        // Fallback: check auth header (e.g., set by reverse proxy / SSO gateway)
+        String headerUser = request.getHeader(AUTH_USER_HEADER);
+        if (headerUser != null && !headerUser.isEmpty()) {
+            return headerUser;
+        }
+
+        // No authenticated user found
+        return null;
+    }
+
+    /**
+     * Check if the given user has admin role.
+     * In production, this should be replaced with a real role/permission system.
+     */
+    private boolean checkAdminRole(HttpServletRequest request, String authUser) {
+        if (authUser == null || authUser.isEmpty()) {
+            return false;
+        }
+        // Check session for admin flag
+        Object isAdminObj = request.getSession(false) != null
+                ? request.getSession(false).getAttribute(AUTH_IS_ADMIN_SESSION_ATTR)
+                : null;
+        if (isAdminObj != null) {
+            return Boolean.TRUE.equals(isAdminObj) || ADMIN_ROLE.equals(isAdminObj.toString());
+        }
+        // Default: non-admin unless explicitly set
+        return false;
+    }
+
+    /**
+     * Determine if the requested URI and parameters indicate an admin-level action.
+     * These include: Agent deletion, gray release management, package management,
+     * service group management, and installation tools.
+     * 
+     * Per security audit: explicit authorization required for:
+     * - delete_agent / routerapi_update_agent_locator / release.action
+     * - add_service_group / add_ip_port / del_ip_port / update_ip_port
+     */
+    private boolean isAdminAction(String requestURI, HttpServletRequest request) {
+        // /interface endpoint: check interface_name parameter for specific admin actions
+        if (requestURI.equals("/interface")) {
+            String interfaceName = request.getParameter("interface_name");
+            if (interfaceName != null) {
+                // Explicit authorization for sensitive interface actions
+                if (interfaceName.equals("deleteagent")
+                        || interfaceName.equals("routerapi_update_agent_locator")
+                        || interfaceName.equals("addservicegroup")
+                        || interfaceName.equals("addipport")
+                        || interfaceName.equals("delipport")
+                        || interfaceName.equals("updateipport")
+                        || interfaceName.equals("release")
+                        || interfaceName.equals("updateagentpackageinfo")
+                        || interfaceName.equals("deleteagentpackage")
+                        || interfaceName.equals("updateagentgraystate")
+                        || interfaceName.equals("addserver")
+                        || interfaceName.equals("delserver")
+                        || interfaceName.equals("updateserver")
+                        || interfaceName.equals("updateagentlocator")
+                        || interfaceName.equals("getservicegroup")) {
+                    return true;
+                }
+            }
+        }
+
+        // *.action routes: specific admin actions
+        // Agent management
+        if (requestURI.equals("/package/grayReleasedPage.action")
+                || requestURI.equals("/package/incGrayReleasedPage.action")) {
+            return true;
+        }
+        // Package management
+        if (requestURI.equals("/package/manage.action")
+                || requestURI.equals("/package/uploadpage.action")
+                || requestURI.equals("/package/updatePackage.action")
+                || requestURI.equals("/package/delPackage.action")
+                || requestURI.equals("/package/release.action")) {
+            return true;
+        }
+        // Installation tools
+        if (requestURI.equals("/router_manager/agent_router_install_page.action")
+                || requestURI.equals("/router_manager/agent_router_install_command.action")) {
+            return true;
+        }
+        // Service group management
+        if (requestURI.equals("/router_manager/service_group_list.action")
+                || requestURI.equals("/router_manager/ip_port_list.action")) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Send an authentication error response (401) in JSON format.
+     */
+    private void sendAuthError(HttpServletResponse response, String message) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json; charset=UTF-8");
+        JSONObject jsonObj = new JSONObject();
+        jsonObj.put("ret_code", 401);
+        jsonObj.put("err_msg", message);
+        jsonObj.put("data", new JSONObject());
+        response.getWriter().write(jsonObj.toString());
+    }
+
+    /**
+     * Send a forbidden error response (403) in JSON format.
+     */
+    private void sendForbiddenError(HttpServletResponse response, String message) throws IOException {
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType("application/json; charset=UTF-8");
+        JSONObject jsonObj = new JSONObject();
+        jsonObj.put("ret_code", 403);
+        jsonObj.put("err_msg", message);
+        jsonObj.put("data", new JSONObject());
+        response.getWriter().write(jsonObj.toString());
+    }
+}

--- a/web/src/main/java/com/qq/seer/servlet/PageServlet.java
+++ b/web/src/main/java/com/qq/seer/servlet/PageServlet.java
@@ -325,7 +325,12 @@ public class PageServlet extends CommonHttpServlet {
 		
 		try {
 			LogUtils.localLogInfo(logId, "grayReleasedPage ...");
-			request.setAttribute("isAdmin", "true");
+			// Removed hardcoded isAdmin=true - admin status must come from authenticated user context
+			Boolean isAdmin = (Boolean) request.getAttribute("SEER_AUTH_IS_ADMIN");
+			if (isAdmin == null) {
+				isAdmin = false;
+			}
+			request.setAttribute("isAdmin", isAdmin.toString());
 			
 			request.getRequestDispatcher("/pages/ftl/package/grayReleasedPage.ftl").forward(request, response);
 			return "1";
@@ -361,7 +366,12 @@ public class PageServlet extends CommonHttpServlet {
 			request.setAttribute("ip", ip);
 			request.setAttribute("os_version", osVersion);
 			request.setAttribute("present_state", state);
-			request.setAttribute("isAdmin", "true");
+			// Removed hardcoded isAdmin=true - admin status must come from authenticated user context
+			Boolean isAdmin = (Boolean) request.getAttribute("SEER_AUTH_IS_ADMIN");
+			if (isAdmin == null) {
+				isAdmin = false;
+			}
+			request.setAttribute("isAdmin", isAdmin.toString());
 			
 			request.getRequestDispatcher("/pages/ftl/package/inc/incGrayReleasedPage.ftl").forward(request, response);
 			return "1";
@@ -426,7 +436,12 @@ public class PageServlet extends CommonHttpServlet {
 			request.setAttribute("service_group", serviceGroup);
 			request.setAttribute("app_name", appName);
 			request.setAttribute("servername", serverName);
-			request.setAttribute("hasPrivileges", true);
+			// Removed hardcoded hasPrivileges=true - privilege must come from authenticated user context
+			Boolean isAdmin = (Boolean) request.getAttribute("SEER_AUTH_IS_ADMIN");
+			if (isAdmin == null) {
+				isAdmin = false;
+			}
+			request.setAttribute("hasPrivileges", isAdmin);
 			
 			request.getRequestDispatcher("/pages/ftl/router_manager/ipPortList.ftl").forward(request, response);
 			return "1";

--- a/web/src/main/webapp/WEB-INF/web.xml
+++ b/web/src/main/webapp/WEB-INF/web.xml
@@ -3,6 +3,21 @@
 	
 	<multipart-form upload-max="100M" />
 	
+	<!-- Authentication and authorization filter for management routes -->
+	<filter>
+		<filter-name>AuthFilter</filter-name>
+		<filter-class>com.qq.seer.common.filter.AuthFilter</filter-class>
+	</filter>
+	<filter-mapping>
+		<filter-name>AuthFilter</filter-name>
+		<url-pattern>/interface</url-pattern>
+	</filter-mapping>
+	<filter-mapping>
+		<filter-name>AuthFilter</filter-name>
+		<url-pattern>*.action</url-pattern>
+	</filter-mapping>
+	<!-- End of AuthFilter configuration -->
+	
 	<display-name>Seer</display-name>
 	
 	<welcome-file-list>


### PR DESCRIPTION
…ials

- Add AuthFilter to intercept /interface and *.action requests, rejecting unauthenticated access with 401 and unauthorized admin operations with 403
- Add AuthContext to provide thread-local authenticated user context for downstream modules
- Remove hardcoded adminrtx username in SeerAgentModule.getServiceGroup()
- Remove hardcoded webadmin key in SeerAgentModule.deleteAgent()
- Replace hardcoded isAdmin/hasPrivileges in PageServlet with context-derived authorization
- Register AuthFilter in web.xml for /interface and *.action routes